### PR TITLE
Tweak naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ foods = {"pie" => "delicious", "broccoli" => "not delicious",
   character_names = ["Daenerys Targaryen", "Jon Snow" ,"Arya Stark", "Tyrion Lannister", "Sansa Stark", "Cersei Lannister", "Margaery Tyrell"]
 
   def downcase_all(array_of_strings)
-    array_of_strings.each do |name|
-      name.downcase
+    array_of_strings.each do |one_string|
+      one_string.downcase
     end
   end
 ```

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ foods = {"pie" => "delicious", "broccoli" => "not delicious",
 
 11 . What is the return value of this method?
 ```ruby
-  characters = ["Daenerys Targaryen", "Jon Snow" ,"Arya Stark", "Tyrion Lannister", "Sansa Stark", "Cersei Lannister", "Margaery Tyrell"]
+  character_names = ["Daenerys Targaryen", "Jon Snow" ,"Arya Stark", "Tyrion Lannister", "Sansa Stark", "Cersei Lannister", "Margaery Tyrell"]
 
-  def downcase_names(characters)
-    characters.each do |names|
-      names.downcase
+  def downcase_all(array_of_strings)
+    array_of_strings.each do |name|
+      name.downcase
     end
   end
 ```


### PR DESCRIPTION
Tweak naming to avoid:
1) Method knowing too much about its usage (i.e. the method could downcase any old string, not just a name)
2) Deceptive pluralization of "names" (it's going to be doing them one at a time)
3) The misconception the array and the parameter would have to be named the same thing for this to work properly